### PR TITLE
support bwd with diff q/k lenght; allow different stride on dq/dk/dv; support packed qkv or kv;

### DIFF
--- a/dkernel/ops/__init__.py
+++ b/dkernel/ops/__init__.py
@@ -1,3 +1,4 @@
+import math
 import torch
 from torch import Tensor
 from typing import Tuple, Dict, Optional, Union
@@ -11,8 +12,8 @@ class _sparse_attention(torch.autograd.Function):
     @staticmethod
     def forward(ctx,
                 q: Tensor,
-                k: Tensor,
-                v: Tensor,
+                k: Optional[Tensor],
+                v: Optional[Tensor],
                 sm_scale: int,
                 layout_csr: Tuple[Tensor, Tensor, int, int],
                 layout_csc: Tuple[Tensor, Tensor, int, int],
@@ -24,14 +25,30 @@ class _sparse_attention(torch.autograd.Function):
         TODO: 1. allow change seqlen in backward
               2. allow cross-attn, bi-directional
         '''
-        # shape constraints
+
+        (q, k, v), (packed_shape, packed_mode, split_qkv) \
+            = get_qkv_and_pack_mode(q, k, v, split_qkv=kwargs.get("split_qkv", None))
+
         ctx.layout_csr = layout_csr
         ctx.layout_csc = layout_csc
+        ctx.packed_shape = packed_shape
+        ctx.packed_mode = packed_mode
+        ctx.split_qkv = split_qkv
+
         seq_dim = 1 if seq_dim is None else seq_dim
         max_seqlen = kwargs.get("max_seqlen", None)
         # causal = kwargs.get('causal', True)
 
         lse = None
+
+        hdim = 3 - (seq_dim or 1) if q.dim() == 4 else 1
+        layout_csr_crow = layout_csr[0]
+        assert layout_csr_crow.size(0) in [1, k.size(hdim), q.size(hdim)], \
+            (f"Input (q, k) have ({q.size(hdim)}, {k.size(hdim)}) heads"
+             f"but the number of heads in the sparse pattern is {layout_csr_crow.size(0)}")
+
+        sm_scale = sm_scale or 1. / math.sqrt(float(q.size(-1)))
+
         assert q.dim() in (3, 4)
         # need_backwards = q.requires_grad() or k.requires_grad() or v.requires_grad()
         if q.dim() == 3:
@@ -49,6 +66,11 @@ class _sparse_attention(torch.autograd.Function):
                                       layout_csr,
                                       max_seqlen=max_seqlen)
         else:
+            # check seqlen
+            if q.dim() == 4:
+                assert k.size(seq_dim) <= max_seqlen, \
+                    (f"Input length {k.size(seq_dim)} is larger "
+                    f"than the maximum length allowed ({max_seqlen})")
             left_paddings = inf_kwargs.get("left_paddings", None)
             seqlens =  inf_kwargs.get("seqlens", None)
             has_paddings = (left_paddings is not None) or (seqlens is not None)
@@ -79,10 +101,52 @@ class _sparse_attention(torch.autograd.Function):
         """
 
         assert ctx.support_backward, ctx.message
-        q, k, v, o, l, m = ctx.saved_tensors
-        assert q.size(ctx.seq_dim) == k.size(ctx.seq_dim), \
-            "Backward supports only when q/k/v have the same sequence length."
-        return _backward(ctx, do, dlse)[:3] + (None, None, None, None, None, None)
+        q, k = ctx.saved_tensors[:2]
+        # assert q.size(ctx.seq_dim) == k.size(ctx.seq_dim), \
+        #     "Backward supports only when q/k/v have the same sequence length."
+
+        dq, dk, dv = None, None, None
+        if ctx.packed_mode == 'packed_qkv':
+            dqkv = q.new_empty(ctx.packed_shape)
+            dq, dk, dv = ctx.split_qkv(dqkv)
+
+        elif ctx.packed_mode == 'packed_kv':
+            dkv = k.new_empty(ctx.packed_shape)
+            dk, dv = ctx.split_qkv(dkv)
+
+        dq, dk, dv = _backward(ctx, do, dlse, dq=dq, dk=dk, dv=dv)[:3]
+
+        if ctx.packed_mode == 'packed_qkv':
+            grads = (dqkv, None, None)
+        elif ctx.packed_mode == 'packed_kv':
+            grads = (dq, dkv, None)
+        else:
+            grads = (dq, dk, dv)
+        return grads + (None, ) * 6
+
+
+def get_qkv_and_pack_mode(q: Tensor, k: Optional[Tensor], v: Optional[Tensor],
+                          split_qkv: Optional[callable] = None
+                          ) -> Tuple[Tuple[Tensor, Tensor, Tensor], Tuple[tuple, str]]:
+    """
+    """
+    qkv_pack_mode = 'split_qkv'
+    packed_shape = None
+    if v is None:
+        # qkv packed or kv packed
+        assert split_qkv is not None, "Callable `split_qkv` must be specified if qkv or kv are packed."
+        # if split_qkv is None:
+        #     split_qkv = lambda qkv: qkv.unbind(0)
+
+        if k is None: # qkv packed
+            packed_shape = q.shape
+            q, k, v = split_qkv(q)
+            qkv_pack_mode = 'packed_qkv'
+        else: # kv packed
+            packed_shape = k.shape
+            k, v = split_qkv(k)
+            qkv_pack_mode = 'packed_kv'
+    return (q, k, v), (packed_shape, qkv_pack_mode, split_qkv)
 
 
 __all__ = ["_sparse_attention"]


### PR DESCRIPTION
1. support bwd with different q/k length for use case of seq-parallel with all-gather of kv;
2. support different strides on dqdkdv: crucial for packed case and future extension (e.g.. diff k dim and v  dim)
3. support packed qkv and packed kv, to avoid concat at backward pass when combining dq/dk/dv